### PR TITLE
Migrate to toml 0.6

### DIFF
--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -10,7 +10,6 @@ clap
 config
 criterion
 duct
-edit
 escape
 expr
 home

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ home = "0.5"
 once_cell = { version = "1", default-features = false }
 serde = { version = "1.0.103", features = ["derive"] }
 shell-escape = "0.1.5"
-toml_edit = { version = "0.17", features = ["easy"] }
+toml = { version = "0.6", default-features = false, features = ["parse"] }
 
 [dev-dependencies]
 anyhow = "1"
@@ -42,4 +42,5 @@ rustversion = "1"
 serde_json = "1"
 static_assertions = "1"
 tempfile = "3"
+toml = "0.6"
 walkdir = "2"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 cargo-config2 = { path = ".." }
 
 criterion = { default-features = false, git = "https://github.com/taiki-e/criterion.rs.git", branch = "dev" } # reduce deps
-fs-err = "2"
-toml = "0.5"
-toml_edit = { version = "0.17", features = ["easy"] }
 
 [[bench]]
 name = "bench"

--- a/bench/bench.rs
+++ b/bench/bench.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, hint::black_box, path::Path};
 
 use cargo_config2::{PathAndArgs, ResolveOptions};
 use criterion::{criterion_group, criterion_main, Criterion};
-use fs_err as fs;
 
 fn fixtures_path() -> &'static Path {
     Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/fixtures"))
@@ -20,16 +19,6 @@ fn test_options() -> ResolveOptions {
 fn reference(c: &mut Criterion) {
     let mut g = c.benchmark_group("reference");
     let dir = &fixtures_path().join("reference");
-    let config_path = &dir.join(".cargo/config.toml");
-    let buf = &black_box(fs::read(config_path).unwrap());
-    g.bench_function("parse_toml_rs", |b| {
-        b.iter(|| black_box(toml::from_slice::<cargo_config2::de::Config>(buf).unwrap()));
-    });
-    g.bench_function("parse_toml_edit", |b| {
-        b.iter(|| {
-            black_box(toml_edit::easy::from_slice::<cargo_config2::de::Config>(buf).unwrap())
-        });
-    });
     g.bench_function("load_config_easy", |b| {
         b.iter(|| {
             let config = cargo_config2::Config::load_with_options(dir, test_options()).unwrap();

--- a/src/de.rs
+++ b/src/de.rs
@@ -136,8 +136,9 @@ impl Config {
         Self::_load_file(path.as_ref())
     }
     fn _load_file(path: &Path) -> Result<Self> {
-        let buf = fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))?;
-        let mut config: Config = toml_edit::easy::from_slice(&buf).with_context(|| {
+        let buf = fs::read_to_string(path)
+            .with_context(|| format!("failed to read `{}`", path.display()))?;
+        let mut config: Config = toml::from_str(&buf).with_context(|| {
             format!("failed to parse `{}` as cargo configuration", path.display())
         })?;
         config.set_path(path);

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ impl From<Error> for io::Error {
             ErrorKind::WithContext(msg, Some(source)) => {
                 let kind = if let Some(e) = source.downcast_ref::<io::Error>() {
                     e.kind()
-                } else if source.downcast_ref::<toml_edit::de::Error>().is_some() {
+                } else if source.downcast_ref::<toml::de::Error>().is_some() {
                     io::ErrorKind::InvalidData
                 } else {
                     io::ErrorKind::Other

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,6 @@ use std::{collections::HashMap, path::Path, str};
 use anyhow::{Context as _, Result};
 use build_info::TARGET;
 use cargo_config2::*;
-use toml_edit::easy as toml;
 
 fn test_options() -> ResolveOptions {
     ResolveOptions::default()
@@ -131,7 +130,7 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config>) -> 
     assert_eq!(config.term.progress.when, Some(When::Auto));
     assert_eq!(config.term.progress.width, Some(80));
 
-    let _config = toml_edit::easy::to_string(&config).unwrap();
+    let _config = toml::to_string(&config).unwrap();
 
     Ok(())
 }
@@ -162,7 +161,7 @@ fn de() {
     let base_config = &de(dir, test_options()).unwrap();
     let config = base_config.clone();
 
-    let _config = toml_edit::easy::to_string(&config).unwrap();
+    let _config = toml::to_string(&config).unwrap();
 
     assert_eq!("", ser(&de::Config::default()));
 }
@@ -210,7 +209,7 @@ fn custom_target() {
         );
         assert_eq!(config.build_target_for_cli([spec_file_name])?, vec![spec_file_name.to_owned()]);
 
-        let _config = toml_edit::easy::to_string(&config).unwrap();
+        let _config = toml::to_string(&config).unwrap();
 
         Ok(())
     }


### PR DESCRIPTION
- toml_edit::easy module is now deprecated in favor of toml.
- Remove parse_toml_rs/parse_toml_edit bench since both have the same parsing implementation.