### PR TITLE
handle empty string rustc wrapper envs

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -676,14 +676,7 @@ mod tests {
             ("CARGO_TERM_PROGRESS_WIDTH", "100"),
         ];
         let mut config = crate::de::Config::default();
-        let cx = &ResolveOptions::default()
-            .env(env_list)
-            .cargo_home(None)
-            .rustc(PathAndArgs::new("rustc"))
-            .into_context();
-        for (k, v) in env_list {
-            assert_eq!(cx.env[k], v, "key={k},value={v}");
-        }
+        let cx = &ResolveOptions::default().env(env_list).into_context();
         config.apply_env(cx).unwrap();
     }
 


### PR DESCRIPTION
If RUSTC_WRAPPER/RUSTC_WORKSPACE_WRAPPER is set to an empty string then this overrides the config and tells cargo not to use a wrapper, per https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads.

I spotted this when upgrading cargo-llvm-cov from an older version, as I have some CI environments where RUSTC_WRAPPER is set to an empty string and it broke cargo-llvm-cov's rustc version detection.