### PR TITLE
Added support the `[cargo-new]` table 

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -2,3 +2,4 @@ cainfo
 fxsr
 unparse
 USERPROFILE
+pijul

--- a/src/de.rs
+++ b/src/de.rs
@@ -66,7 +66,12 @@ pub struct Config {
     #[serde(default)]
     #[serde(skip_serializing_if = "FutureIncompatReportConfig::is_none")]
     pub future_incompat_report: FutureIncompatReportConfig,
-    // TODO: cargo-new
+    /// The `[cargo-new]` table.
+    ///
+    /// [reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#cargo-new)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "CargoNewConfig::is_none")]
+    pub cargo_new: CargoNewConfig,
     /// The `[http]` table.
     ///
     /// [reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#http)
@@ -441,6 +446,64 @@ pub struct FutureIncompatReportConfig {
     /// [reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#future-incompat-reportfrequency)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frequency: Option<Value<Frequency>>,
+}
+
+/// The `[cargo-new]` table.
+///
+/// [reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#cargo-new)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct CargoNewConfig {
+    /// Specifies the source control system to use for initializing a new repository.
+    /// Valid values are git, hg (for Mercurial), pijul, fossil or none to disable this behavior.
+    /// Defaults to git, or none if already inside a VCS repository. Can be overridden with the --vcs CLI option.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vcs: Option<Value<VersionControlSoftware>>,
+}
+
+#[allow(clippy::exhaustive_enums)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VersionControlSoftware {
+    /// Git
+    Git,
+    /// Mercurial
+    #[serde(rename = "hg")]
+    Mercurial,
+    /// Pijul
+    Pijul,
+    /// Fossil
+    Fossil,
+    /// No VCS
+    None,
+}
+
+impl VersionControlSoftware {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            VersionControlSoftware::Git => "git",
+            VersionControlSoftware::Mercurial => "hg",
+            VersionControlSoftware::Pijul => "pijul",
+            VersionControlSoftware::Fossil => "fossil",
+            VersionControlSoftware::None => "none",
+        }
+    }
+}
+
+impl FromStr for VersionControlSoftware {
+    type Err = Error;
+
+    fn from_str(vcs: &str) -> Result<Self, Self::Err> {
+        match vcs {
+            "git" => Ok(Self::Git),
+            "hg" => Ok(Self::Mercurial),
+            "pijul" => Ok(Self::Pijul),
+            "fossil" => Ok(Self::Fossil),
+            "none" => Ok(Self::None),
+            other => bail!("must be git, hg, pijul, fossil, none, but found `{other}`"),
+        }
+    }
 }
 
 /// The `[http]` table.

--- a/src/de.rs
+++ b/src/de.rs
@@ -462,9 +462,9 @@ pub struct CargoNewConfig {
     pub vcs: Option<Value<VersionControlSoftware>>,
 }
 
-#[allow(clippy::exhaustive_enums)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum VersionControlSoftware {
     /// Git
     Git,

--- a/src/gen/assert_impl.rs
+++ b/src/gen/assert_impl.rs
@@ -83,6 +83,16 @@ const _: fn() = || {
     assert_unpin::<crate::de::FutureIncompatReportConfig>();
     assert_unwind_safe::<crate::de::FutureIncompatReportConfig>();
     assert_ref_unwind_safe::<crate::de::FutureIncompatReportConfig>();
+    assert_send::<crate::de::CargoNewConfig>();
+    assert_sync::<crate::de::CargoNewConfig>();
+    assert_unpin::<crate::de::CargoNewConfig>();
+    assert_unwind_safe::<crate::de::CargoNewConfig>();
+    assert_ref_unwind_safe::<crate::de::CargoNewConfig>();
+    assert_send::<crate::de::VersionControlSoftware>();
+    assert_sync::<crate::de::VersionControlSoftware>();
+    assert_unpin::<crate::de::VersionControlSoftware>();
+    assert_unwind_safe::<crate::de::VersionControlSoftware>();
+    assert_ref_unwind_safe::<crate::de::VersionControlSoftware>();
     assert_send::<crate::de::HttpConfig>();
     assert_sync::<crate::de::HttpConfig>();
     assert_unpin::<crate::de::HttpConfig>();
@@ -188,6 +198,11 @@ const _: fn() = || {
     assert_unpin::<crate::easy::FutureIncompatReportConfig>();
     assert_unwind_safe::<crate::easy::FutureIncompatReportConfig>();
     assert_ref_unwind_safe::<crate::easy::FutureIncompatReportConfig>();
+    assert_send::<crate::easy::CargoNewConfig>();
+    assert_sync::<crate::easy::CargoNewConfig>();
+    assert_unpin::<crate::easy::CargoNewConfig>();
+    assert_unwind_safe::<crate::easy::CargoNewConfig>();
+    assert_ref_unwind_safe::<crate::easy::CargoNewConfig>();
     assert_send::<crate::easy::HttpConfig>();
     assert_sync::<crate::easy::HttpConfig>();
     assert_unpin::<crate::easy::HttpConfig>();

--- a/src/gen/de.rs
+++ b/src/gen/de.rs
@@ -13,6 +13,7 @@ impl Merge for crate::de::Config {
         self.doc.merge(low.doc, force)?;
         self.env.merge(low.env, force)?;
         self.future_incompat_report.merge(low.future_incompat_report, force)?;
+        self.cargo_new.merge(low.cargo_new, force)?;
         self.http.merge(low.http, force)?;
         self.net.merge(low.net, force)?;
         self.registries.merge(low.registries, force)?;
@@ -29,6 +30,7 @@ impl SetPath for crate::de::Config {
         self.doc.set_path(path);
         self.env.set_path(path);
         self.future_incompat_report.set_path(path);
+        self.cargo_new.set_path(path);
         self.http.set_path(path);
         self.net.set_path(path);
         self.registries.set_path(path);
@@ -117,6 +119,17 @@ impl Merge for crate::de::FutureIncompatReportConfig {
 impl SetPath for crate::de::FutureIncompatReportConfig {
     fn set_path(&mut self, path: &Path) {
         self.frequency.set_path(path);
+    }
+}
+impl Merge for crate::de::CargoNewConfig {
+    fn merge(&mut self, low: Self, force: bool) -> Result<()> {
+        self.vcs.merge(low.vcs, force)?;
+        Ok(())
+    }
+}
+impl SetPath for crate::de::CargoNewConfig {
+    fn set_path(&mut self, path: &Path) {
+        self.vcs.set_path(path);
     }
 }
 impl Merge for crate::de::HttpConfig {

--- a/src/gen/is_none.rs
+++ b/src/gen/is_none.rs
@@ -23,6 +23,11 @@ impl crate::easy::FutureIncompatReportConfig {
         self.frequency.is_none()
     }
 }
+impl crate::easy::CargoNewConfig {
+    pub(crate) fn is_none(&self) -> bool {
+        self.vcs.is_none()
+    }
+}
 impl crate::easy::HttpConfig {
     pub(crate) fn is_none(&self) -> bool {
         self.debug.is_none() && self.proxy.is_none() && self.timeout.is_none()
@@ -70,6 +75,11 @@ impl crate::de::DocConfig {
 impl crate::de::FutureIncompatReportConfig {
     pub(crate) fn is_none(&self) -> bool {
         self.frequency.is_none()
+    }
+}
+impl crate::de::CargoNewConfig {
+    pub(crate) fn is_none(&self) -> bool {
+        self.vcs.is_none()
     }
 }
 impl crate::de::HttpConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ mod value;
 mod walk;
 
 #[doc(no_inline)]
-pub use crate::de::{Color, Frequency, RegistriesProtocol, When};
+pub use crate::de::{Color, Frequency, RegistriesProtocol, VersionControlSoftware, When};
 pub use crate::{
     easy::{
         BuildConfig, Config, DocConfig, EnvConfigValue, Flags, FutureIncompatReportConfig,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -3,7 +3,7 @@
 use std::collections::{btree_map, BTreeMap};
 
 use crate::{
-    de::{self, RegistriesProtocol},
+    de::{self, RegistriesProtocol, VersionControlSoftware},
     error::{Context as _, Result},
     value::Value,
     Color, Frequency, When,
@@ -47,6 +47,7 @@ merge_non_container!(i32);
 merge_non_container!(u32);
 merge_non_container!(String);
 merge_non_container!(Color);
+merge_non_container!(VersionControlSoftware);
 merge_non_container!(Frequency);
 merge_non_container!(When);
 merge_non_container!(RegistriesProtocol);

--- a/tests/fixtures/reference/.cargo/config.toml
+++ b/tests/fixtures/reference/.cargo/config.toml
@@ -38,8 +38,8 @@ ENV_VAR_NAME_3 = { value = "relative/path", relative = true }
 [future-incompat-report]
 frequency = 'always' # when to display a notification about a future incompat report
 
-# [cargo-new]
-# vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
+[cargo-new]
+vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
 
 [http]
 debug = false # HTTP debugging

--- a/tests/fixtures/reference/.cargo/config.toml
+++ b/tests/fixtures/reference/.cargo/config.toml
@@ -39,7 +39,7 @@ ENV_VAR_NAME_3 = { value = "relative/path", relative = true }
 frequency = 'always' # when to display a notification about a future incompat report
 
 [cargo-new]
-vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
+vcs = "none" # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
 
 [http]
 debug = false # HTTP debugging

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,6 @@ use std::{collections::HashMap, path::Path, str};
 use anyhow::{Context as _, Result};
 use build_context::TARGET;
 use cargo_config2::*;
-use de::VersionControlSoftware;
 use helper::*;
 
 fn test_options() -> ResolveOptions {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -72,7 +72,7 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config>) -> 
     assert_eq!(config.future_incompat_report.frequency, Some(Frequency::Always));
 
     // TODO
-    // [cargo-new]
+    assert_eq!(config.cargo_new.vcs, None);
 
     // [http]
     assert_eq!(config.http.debug, Some(false));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, path::Path, str};
 use anyhow::{Context as _, Result};
 use build_context::TARGET;
 use cargo_config2::*;
+use de::VersionControlSoftware;
 use helper::*;
 
 fn test_options() -> ResolveOptions {
@@ -71,8 +72,8 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config>) -> 
     // [future-incompat-report]
     assert_eq!(config.future_incompat_report.frequency, Some(Frequency::Always));
 
-    // TODO
-    assert_eq!(config.cargo_new.vcs, None);
+    // [cargo-new]
+    assert_eq!(config.cargo_new.vcs, Some(VersionControlSoftware::None));
 
     // [http]
     assert_eq!(config.http.debug, Some(false));


### PR DESCRIPTION
Hey there! :wave: 

I also added support for the [`cargo-new`](https://doc.rust-lang.org/cargo/reference/config.html#cargo-new) table which only has 1 none deprecated property. 
I did not add the deprecated fields. 