### PR TITLE
Added `build.build-dir` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ allowed_external_types = [
 [lib]
 doc-scrape-examples = false
 
+[features]
+# Enables unstable Cargo config fields.
+unstable = []
+
 # Note: serde is public dependencies.
 [dependencies]
 serde = "1.0.165"

--- a/src/de.rs
+++ b/src/de.rs
@@ -373,6 +373,7 @@ pub struct BuildConfig {
     /// specified is the value of build.target-dir
     ///
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
+    #[cfg(feature = "unstable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dir: Option<Value<String>>,
     /// Extra command-line flags to pass to rustc. The value may be an array

--- a/src/de.rs
+++ b/src/de.rs
@@ -373,7 +373,6 @@ pub struct BuildConfig {
     /// specified is the value of build.target-dir
     ///
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
-    #[cfg(feature = "unstable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dir: Option<Value<String>>,
     /// Extra command-line flags to pass to rustc. The value may be an array

--- a/src/de.rs
+++ b/src/de.rs
@@ -369,6 +369,12 @@ pub struct BuildConfig {
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildtarget)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_dir: Option<Value<String>>,
+    /// The path to where all compiler intermediate artifacts are placed. The default if not
+    /// specified is the value of build.target-dir
+    ///
+    /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_dir: Option<Value<String>>,
     /// Extra command-line flags to pass to rustc. The value may be an array
     /// of strings or a space-separated string.
     ///

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -514,6 +514,7 @@ pub struct BuildConfig {
     /// specified is the value of build.target-dir
     ///
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
+    #[cfg(feature = "unstable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dir: Option<PathBuf>,
     /// Extra command-line flags to pass to rustc. The value may be an array
@@ -580,6 +581,7 @@ impl BuildConfig {
                 .collect()
         });
         let target_dir = de.target_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
+        #[cfg(feature = "unstable")]
         let build_dir = de.build_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
         let de_rustflags = de.rustflags.clone();
         let rustflags =
@@ -600,6 +602,7 @@ impl BuildConfig {
             rustdoc,
             target,
             target_dir,
+            #[cfg(feature = "unstable")]
             build_dir,
             rustflags,
             rustdocflags,

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -514,6 +514,9 @@ pub struct BuildConfig {
     /// specified is the value of build.target-dir
     ///
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
+    ///
+    /// **Note:** If a template variable is used the path will be unresolved. For available template
+    /// variables see the Cargo reference.
     #[cfg(feature = "unstable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dir: Option<PathBuf>,
@@ -582,7 +585,13 @@ impl BuildConfig {
         });
         let target_dir = de.target_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
         #[cfg(feature = "unstable")]
-        let build_dir = de.build_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
+        let build_dir = de.build_dir.map(|v| {
+            if v.val.starts_with("{workspace-root}") || v.val.starts_with("{cargo-cache-home}") {
+                return PathBuf::from(v.val);
+            }
+
+            v.resolve_as_path(current_dir).into_owned()
+        });
         let de_rustflags = de.rustflags.clone();
         let rustflags =
             de.rustflags.map(|v| Flags { flags: v.flags.into_iter().map(|v| v.val).collect() });

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -517,7 +517,6 @@ pub struct BuildConfig {
     ///
     /// **Note:** If a template variable is used the path will be unresolved. For available template
     /// variables see the Cargo reference.
-    #[cfg(feature = "unstable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dir: Option<PathBuf>,
     /// Extra command-line flags to pass to rustc. The value may be an array
@@ -584,7 +583,6 @@ impl BuildConfig {
                 .collect()
         });
         let target_dir = de.target_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
-        #[cfg(feature = "unstable")]
         let build_dir = de.build_dir.map(|v| {
             if v.val.starts_with("{workspace-root}") || v.val.starts_with("{cargo-cache-home}") {
                 return PathBuf::from(v.val);
@@ -611,7 +609,6 @@ impl BuildConfig {
             rustdoc,
             target,
             target_dir,
-            #[cfg(feature = "unstable")]
             build_dir,
             rustflags,
             rustdocflags,

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -510,6 +510,12 @@ pub struct BuildConfig {
     /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildtarget)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_dir: Option<PathBuf>,
+    /// The path to where all compiler intermediate artifacts are placed. The default if not
+    /// specified is the value of build.target-dir
+    ///
+    /// [Cargo Reference](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_dir: Option<PathBuf>,
     /// Extra command-line flags to pass to rustc. The value may be an array
     /// of strings or a space-separated string.
     ///
@@ -574,6 +580,7 @@ impl BuildConfig {
                 .collect()
         });
         let target_dir = de.target_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
+        let build_dir = de.build_dir.map(|v| v.resolve_as_path(current_dir).into_owned());
         let de_rustflags = de.rustflags.clone();
         let rustflags =
             de.rustflags.map(|v| Flags { flags: v.flags.into_iter().map(|v| v.val).collect() });
@@ -593,6 +600,7 @@ impl BuildConfig {
             rustdoc,
             target,
             target_dir,
+            build_dir,
             rustflags,
             rustdocflags,
             incremental,

--- a/src/env.rs
+++ b/src/env.rs
@@ -64,15 +64,12 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.index = index;
                     } else {
-                        self.registries.insert(
-                            k.to_owned(),
-                            RegistriesConfigValue {
-                                index,
-                                token: None,
-                                credential_provider: None,
-                                protocol: None,
-                            },
-                        );
+                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
+                            index,
+                            token: None,
+                            credential_provider: None,
+                            protocol: None,
+                        });
                     }
                 } else if let Some(k) = k.strip_suffix("_TOKEN") {
                     let v = v.to_str().ok_or_else(error_env_not_unicode_redacted)?;
@@ -80,15 +77,12 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.token = token;
                     } else {
-                        self.registries.insert(
-                            k.to_owned(),
-                            RegistriesConfigValue {
-                                index: None,
-                                token,
-                                credential_provider: None,
-                                protocol: None,
-                            },
-                        );
+                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
+                            index: None,
+                            token,
+                            credential_provider: None,
+                            protocol: None,
+                        });
                     }
                 } else if let Some(k) = k.strip_suffix("_CREDENTIAL_PROVIDER") {
                     let credential_provider = Some(
@@ -98,15 +92,12 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.credential_provider = credential_provider;
                     } else {
-                        self.registries.insert(
-                            k.to_owned(),
-                            RegistriesConfigValue {
-                                index: None,
-                                token: None,
-                                credential_provider,
-                                protocol: None,
-                            },
-                        );
+                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
+                            index: None,
+                            token: None,
+                            credential_provider,
+                            protocol: None,
+                        });
                     }
                 } else if k == "CRATES_IO_PROTOCOL" {
                     let k = "crates-io";
@@ -116,15 +107,12 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.protocol = protocol;
                     } else {
-                        self.registries.insert(
-                            k.to_owned(),
-                            RegistriesConfigValue {
-                                index: None,
-                                token: None,
-                                credential_provider: None,
-                                protocol,
-                            },
-                        );
+                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
+                            index: None,
+                            token: None,
+                            credential_provider: None,
+                            protocol,
+                        });
                     }
                 }
             }

--- a/src/env.rs
+++ b/src/env.rs
@@ -64,12 +64,15 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.index = index;
                     } else {
-                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
-                            index,
-                            token: None,
-                            credential_provider: None,
-                            protocol: None,
-                        });
+                        self.registries.insert(
+                            k.to_owned(),
+                            RegistriesConfigValue {
+                                index,
+                                token: None,
+                                credential_provider: None,
+                                protocol: None,
+                            },
+                        );
                     }
                 } else if let Some(k) = k.strip_suffix("_TOKEN") {
                     let v = v.to_str().ok_or_else(error_env_not_unicode_redacted)?;
@@ -77,12 +80,15 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.token = token;
                     } else {
-                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
-                            index: None,
-                            token,
-                            credential_provider: None,
-                            protocol: None,
-                        });
+                        self.registries.insert(
+                            k.to_owned(),
+                            RegistriesConfigValue {
+                                index: None,
+                                token,
+                                credential_provider: None,
+                                protocol: None,
+                            },
+                        );
                     }
                 } else if let Some(k) = k.strip_suffix("_CREDENTIAL_PROVIDER") {
                     let credential_provider = Some(
@@ -92,12 +98,15 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.credential_provider = credential_provider;
                     } else {
-                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
-                            index: None,
-                            token: None,
-                            credential_provider,
-                            protocol: None,
-                        });
+                        self.registries.insert(
+                            k.to_owned(),
+                            RegistriesConfigValue {
+                                index: None,
+                                token: None,
+                                credential_provider,
+                                protocol: None,
+                            },
+                        );
                     }
                 } else if k == "CRATES_IO_PROTOCOL" {
                     let k = "crates-io";
@@ -107,12 +116,15 @@ impl Config {
                     if let Some(registries_config_value) = self.registries.get_mut(k) {
                         registries_config_value.protocol = protocol;
                     } else {
-                        self.registries.insert(k.to_owned(), RegistriesConfigValue {
-                            index: None,
-                            token: None,
-                            credential_provider: None,
-                            protocol,
-                        });
+                        self.registries.insert(
+                            k.to_owned(),
+                            RegistriesConfigValue {
+                                index: None,
+                                token: None,
+                                credential_provider: None,
+                                protocol,
+                            },
+                        );
                     }
                 }
             }
@@ -213,7 +225,6 @@ impl ApplyEnv for BuildConfig {
         }
 
         // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir
-        #[cfg(feature = "unstable")]
         if let Some(build_dir) = cx.env("CARGO_BUILD_BUILD_DIR")? {
             self.build_dir = Some(build_dir);
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -212,6 +212,12 @@ impl ApplyEnv for BuildConfig {
             self.target_dir = Some(target_dir);
         }
 
+        // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir
+        #[cfg(feature = "unstable")]
+        if let Some(build_dir) = cx.env("CARGO_BUILD_BUILD_DIR")? {
+            self.build_dir = Some(build_dir);
+        }
+
         // 1. CARGO_ENCODED_RUSTFLAGS
         // 2. RUSTFLAGS
         // 3. target.<triple>.rustflags (CARGO_TARGET_<triple>_RUSTFLAGS) and target.<cfg>.rustflags

--- a/src/gen/de.rs
+++ b/src/gen/de.rs
@@ -52,7 +52,7 @@ impl Merge for crate::de::BuildConfig {
         self.rustdoc.merge(low.rustdoc, force)?;
         self.target.merge(low.target, force)?;
         self.target_dir.merge(low.target_dir, force)?;
-        self.build_dir.merge(low.build_dir, force)?;
+        #[cfg(feature = "unstable")] self.build_dir.merge(low.build_dir, force)?;
         self.rustflags.merge(low.rustflags, force)?;
         self.rustdocflags.merge(low.rustdocflags, force)?;
         self.incremental.merge(low.incremental, force)?;
@@ -69,7 +69,7 @@ impl SetPath for crate::de::BuildConfig {
         self.rustdoc.set_path(path);
         self.target.set_path(path);
         self.target_dir.set_path(path);
-        self.build_dir.set_path(path);
+        #[cfg(feature = "unstable")] self.build_dir.set_path(path);
         self.rustflags.set_path(path);
         self.rustdocflags.set_path(path);
         self.incremental.set_path(path);

--- a/src/gen/de.rs
+++ b/src/gen/de.rs
@@ -52,7 +52,7 @@ impl Merge for crate::de::BuildConfig {
         self.rustdoc.merge(low.rustdoc, force)?;
         self.target.merge(low.target, force)?;
         self.target_dir.merge(low.target_dir, force)?;
-        #[cfg(feature = "unstable")] self.build_dir.merge(low.build_dir, force)?;
+        self.build_dir.merge(low.build_dir, force)?;
         self.rustflags.merge(low.rustflags, force)?;
         self.rustdocflags.merge(low.rustdocflags, force)?;
         self.incremental.merge(low.incremental, force)?;
@@ -69,7 +69,7 @@ impl SetPath for crate::de::BuildConfig {
         self.rustdoc.set_path(path);
         self.target.set_path(path);
         self.target_dir.set_path(path);
-        #[cfg(feature = "unstable")] self.build_dir.set_path(path);
+        self.build_dir.set_path(path);
         self.rustflags.set_path(path);
         self.rustdocflags.set_path(path);
         self.incremental.set_path(path);

--- a/src/gen/de.rs
+++ b/src/gen/de.rs
@@ -52,6 +52,7 @@ impl Merge for crate::de::BuildConfig {
         self.rustdoc.merge(low.rustdoc, force)?;
         self.target.merge(low.target, force)?;
         self.target_dir.merge(low.target_dir, force)?;
+        self.build_dir.merge(low.build_dir, force)?;
         self.rustflags.merge(low.rustflags, force)?;
         self.rustdocflags.merge(low.rustdocflags, force)?;
         self.incremental.merge(low.incremental, force)?;
@@ -68,6 +69,7 @@ impl SetPath for crate::de::BuildConfig {
         self.rustdoc.set_path(path);
         self.target.set_path(path);
         self.target_dir.set_path(path);
+        self.build_dir.set_path(path);
         self.rustflags.set_path(path);
         self.rustdocflags.set_path(path);
         self.incremental.set_path(path);

--- a/src/gen/is_none.rs
+++ b/src/gen/is_none.rs
@@ -6,12 +6,15 @@
 #![cfg_attr(rustfmt, rustfmt::skip)]
 impl crate::easy::BuildConfig {
     pub(crate) fn is_none(&self) -> bool {
+        #[cfg(feature = "unstable")]
+        let build_dir_is_none = self.build_dir.is_none();
+        #[cfg(not(feature = "unstable"))]
+        let build_dir_is_none = true;
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
-            && self.target.is_none() && self.target_dir.is_none()
-            && self.build_dir.is_none() && self.rustflags.is_none()
-            && self.rustdocflags.is_none() && self.incremental.is_none()
-            && self.dep_info_basedir.is_none()
+            && self.target.is_none() && self.target_dir.is_none() && build_dir_is_none
+            && self.rustflags.is_none() && self.rustdocflags.is_none()
+            && self.incremental.is_none() && self.dep_info_basedir.is_none()
     }
 }
 impl crate::easy::DocConfig {
@@ -62,12 +65,15 @@ impl crate::easy::TermProgressConfig {
 }
 impl crate::de::BuildConfig {
     pub(crate) fn is_none(&self) -> bool {
+        #[cfg(feature = "unstable")]
+        let build_dir_is_none = self.build_dir.is_none();
+        #[cfg(not(feature = "unstable"))]
+        let build_dir_is_none = true;
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
-            && self.target.is_none() && self.target_dir.is_none()
-            && self.build_dir.is_none() && self.rustflags.is_none()
-            && self.rustdocflags.is_none() && self.incremental.is_none()
-            && self.dep_info_basedir.is_none()
+            && self.target.is_none() && self.target_dir.is_none() && build_dir_is_none
+            && self.rustflags.is_none() && self.rustdocflags.is_none()
+            && self.incremental.is_none() && self.dep_info_basedir.is_none()
     }
 }
 impl crate::de::DocConfig {

--- a/src/gen/is_none.rs
+++ b/src/gen/is_none.rs
@@ -6,15 +6,12 @@
 #![cfg_attr(rustfmt, rustfmt::skip)]
 impl crate::easy::BuildConfig {
     pub(crate) fn is_none(&self) -> bool {
-        #[cfg(feature = "unstable")]
-        let build_dir_is_none = self.build_dir.is_none();
-        #[cfg(not(feature = "unstable"))]
-        let build_dir_is_none = true;
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
-            && self.target.is_none() && self.target_dir.is_none() && build_dir_is_none
-            && self.rustflags.is_none() && self.rustdocflags.is_none()
-            && self.incremental.is_none() && self.dep_info_basedir.is_none()
+            && self.target.is_none() && self.target_dir.is_none()
+            && self.build_dir.is_none() && self.rustflags.is_none()
+            && self.rustdocflags.is_none() && self.incremental.is_none()
+            && self.dep_info_basedir.is_none()
     }
 }
 impl crate::easy::DocConfig {
@@ -65,15 +62,12 @@ impl crate::easy::TermProgressConfig {
 }
 impl crate::de::BuildConfig {
     pub(crate) fn is_none(&self) -> bool {
-        #[cfg(feature = "unstable")]
-        let build_dir_is_none = self.build_dir.is_none();
-        #[cfg(not(feature = "unstable"))]
-        let build_dir_is_none = true;
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
-            && self.target.is_none() && self.target_dir.is_none() && build_dir_is_none
-            && self.rustflags.is_none() && self.rustdocflags.is_none()
-            && self.incremental.is_none() && self.dep_info_basedir.is_none()
+            && self.target.is_none() && self.target_dir.is_none()
+            && self.build_dir.is_none() && self.rustflags.is_none()
+            && self.rustdocflags.is_none() && self.incremental.is_none()
+            && self.dep_info_basedir.is_none()
     }
 }
 impl crate::de::DocConfig {

--- a/src/gen/is_none.rs
+++ b/src/gen/is_none.rs
@@ -9,8 +9,9 @@ impl crate::easy::BuildConfig {
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
             && self.target.is_none() && self.target_dir.is_none()
-            && self.rustflags.is_none() && self.rustdocflags.is_none()
-            && self.incremental.is_none() && self.dep_info_basedir.is_none()
+            && self.build_dir.is_none() && self.rustflags.is_none()
+            && self.rustdocflags.is_none() && self.incremental.is_none()
+            && self.dep_info_basedir.is_none()
     }
 }
 impl crate::easy::DocConfig {
@@ -64,8 +65,9 @@ impl crate::de::BuildConfig {
         self.jobs.is_none() && self.rustc.is_none() && self.rustc_wrapper.is_none()
             && self.rustc_workspace_wrapper.is_none() && self.rustdoc.is_none()
             && self.target.is_none() && self.target_dir.is_none()
-            && self.rustflags.is_none() && self.rustdocflags.is_none()
-            && self.incremental.is_none() && self.dep_info_basedir.is_none()
+            && self.build_dir.is_none() && self.rustflags.is_none()
+            && self.rustdocflags.is_none() && self.incremental.is_none()
+            && self.dep_info_basedir.is_none()
     }
 }
 impl crate::de::DocConfig {

--- a/src/gen/tests/track_size.txt
+++ b/src/gen/tests/track_size.txt
@@ -1,5 +1,5 @@
-cargo_config2::de::Config: 1784
-cargo_config2::de::BuildConfig: 544
+cargo_config2::de::Config: 1816
+cargo_config2::de::BuildConfig: 600
 cargo_config2::de::TargetConfig: 208
 cargo_config2::de::DocConfig: 88
 cargo_config2::de::EnvConfigValue: 136

--- a/src/gen/tests/track_size.txt
+++ b/src/gen/tests/track_size.txt
@@ -1,4 +1,4 @@
-cargo_config2::de::Config: 1816
+cargo_config2::de::Config: 1840
 cargo_config2::de::BuildConfig: 600
 cargo_config2::de::TargetConfig: 208
 cargo_config2::de::DocConfig: 88
@@ -25,8 +25,8 @@ cargo_config2::de::ConfigRelativePath: 56
 cargo_config2::de::PathAndArgs: 88
 cargo_config2::de::StringList: 32
 cargo_config2::de::StringOrArray: 56
-cargo_config2::easy::Config: 1064
-cargo_config2::easy::BuildConfig: 296
+cargo_config2::easy::Config: 1088
+cargo_config2::easy::BuildConfig: 320
 cargo_config2::easy::TargetConfig: 120
 cargo_config2::easy::DocConfig: 48
 cargo_config2::easy::EnvConfigValue: 32

--- a/tests/fixtures/reference/.cargo/config.toml
+++ b/tests/fixtures/reference/.cargo/config.toml
@@ -19,6 +19,7 @@ rustc-workspace-wrapper = "…" # run this wrapper instead of `rustc` for worksp
 rustdoc = "rustdoc" # the doc generator tool
 target = "triple" # build for the target triple (ignored by `cargo install`)
 target-dir = "target" # path of where to place all generated artifacts
+build-dir = "target" # path of where intermediate build artifacts will be stored
 rustflags = ["…", "…"] # custom flags to pass to all compiler invocations
 rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
 incremental = true # whether or not to enable incremental compilation

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -47,6 +47,7 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     assert_eq!(config.build.rustdoc.as_ref().unwrap().as_os_str(), "rustdoc");
     assert_eq!(config.build.target.as_ref().unwrap(), &vec!["triple".into()]);
     assert_eq!(config.build.target_dir.as_ref().unwrap(), &dir.join("target"));
+    #[cfg(feature = "unstable")]
     assert_eq!(config.build.build_dir.as_ref().unwrap(), &dir.join("target"));
     assert_eq!(config.build.rustflags, Some(["…", "…"].into()));
     assert_eq!(config.build.rustdocflags, Some(["…", "…"].into()));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -172,10 +172,9 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     assert_eq!(config.registry.default.as_deref(), Some("crates-io"));
     assert_eq!(config.registry.token.as_deref(), Some("00000000000000000000000000000000000"));
     assert_eq!(config.registry.credential_provider, Some(CredentialProvider::CargoToken));
-    assert_eq!(
-        config.registry.global_credential_providers.as_ref(),
-        [CredentialProvider::CargoToken]
-    );
+    assert_eq!(config.registry.global_credential_providers.as_ref(), [
+        CredentialProvider::CargoToken
+    ]);
 
     // [source.<name>]
     assert_eq!(config.source["vendored-sources"].directory, Some(dir.join("vendor")));
@@ -346,10 +345,9 @@ fn custom_target() {
                 .as_os_str(),
             spec_file_name
         );
-        assert_eq!(
-            config.build_target_for_cli([spec_file_name]).unwrap(),
-            vec![spec_file_name.to_owned()]
-        );
+        assert_eq!(config.build_target_for_cli([spec_file_name]).unwrap(), vec![
+            spec_file_name.to_owned()
+        ]);
 
         let _config = toml::to_string(&config).unwrap();
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -47,7 +47,6 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     assert_eq!(config.build.rustdoc.as_ref().unwrap().as_os_str(), "rustdoc");
     assert_eq!(config.build.target.as_ref().unwrap(), &vec!["triple".into()]);
     assert_eq!(config.build.target_dir.as_ref().unwrap(), &dir.join("target"));
-    #[cfg(feature = "unstable")]
     assert_eq!(config.build.build_dir.as_ref().unwrap(), &dir.join("target"));
     assert_eq!(config.build.rustflags, Some(["…", "…"].into()));
     assert_eq!(config.build.rustdocflags, Some(["…", "…"].into()));
@@ -173,9 +172,10 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     assert_eq!(config.registry.default.as_deref(), Some("crates-io"));
     assert_eq!(config.registry.token.as_deref(), Some("00000000000000000000000000000000000"));
     assert_eq!(config.registry.credential_provider, Some(CredentialProvider::CargoToken));
-    assert_eq!(config.registry.global_credential_providers.as_ref(), [
-        CredentialProvider::CargoToken
-    ]);
+    assert_eq!(
+        config.registry.global_credential_providers.as_ref(),
+        [CredentialProvider::CargoToken]
+    );
 
     // [source.<name>]
     assert_eq!(config.source["vendored-sources"].directory, Some(dir.join("vendor")));
@@ -346,9 +346,10 @@ fn custom_target() {
                 .as_os_str(),
             spec_file_name
         );
-        assert_eq!(config.build_target_for_cli([spec_file_name]).unwrap(), vec![
-            spec_file_name.to_owned()
-        ]);
+        assert_eq!(
+            config.build_target_for_cli([spec_file_name]).unwrap(),
+            vec![spec_file_name.to_owned()]
+        );
 
         let _config = toml::to_string(&config).unwrap();
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -47,6 +47,7 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     assert_eq!(config.build.rustdoc.as_ref().unwrap().as_os_str(), "rustdoc");
     assert_eq!(config.build.target.as_ref().unwrap(), &vec!["triple".into()]);
     assert_eq!(config.build.target_dir.as_ref().unwrap(), &dir.join("target"));
+    assert_eq!(config.build.build_dir.as_ref().unwrap(), &dir.join("target"));
     assert_eq!(config.build.rustflags, Some(["…", "…"].into()));
     assert_eq!(config.build.rustdocflags, Some(["…", "…"].into()));
     assert_eq!(config.build.incremental, Some(true));


### PR DESCRIPTION
This PR adds `build_dir` to the `BuildConfig`

See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir

closes #28