### PR TITLE
Handle target names that contain "."

### DIFF
--- a/src/gen/de.rs
+++ b/src/gen/de.rs
@@ -82,6 +82,7 @@ impl Merge for crate::de::TargetConfig {
         self.runner.merge(low.runner, force)?;
         self.rustflags.merge(low.rustflags, force)?;
         self.rustdocflags.merge(low.rustdocflags, force)?;
+        self.rest.merge(low.rest, force)?;
         Ok(())
     }
 }
@@ -91,6 +92,7 @@ impl SetPath for crate::de::TargetConfig {
         self.runner.set_path(path);
         self.rustflags.set_path(path);
         self.rustdocflags.set_path(path);
+        self.rest.set_path(path);
     }
 }
 impl Merge for crate::de::DocConfig {

--- a/src/gen/tests/track_size.txt
+++ b/src/gen/tests/track_size.txt
@@ -1,6 +1,6 @@
 cargo_config2::de::Config: 1840
 cargo_config2::de::BuildConfig: 600
-cargo_config2::de::TargetConfig: 208
+cargo_config2::de::TargetConfig: 232
 cargo_config2::de::DocConfig: 88
 cargo_config2::de::EnvConfigValue: 136
 cargo_config2::de::FutureIncompatReportConfig: 40

--- a/tests/fixtures/reference/.cargo/config.toml
+++ b/tests/fixtures/reference/.cargo/config.toml
@@ -145,6 +145,12 @@ rustdocflags = ["d", "dd"] # custom flags for `rustdoc`
 runner = "c" # wrapper to run executables
 rustflags = ["c", "cc"] # custom flags for `rustc`
 
+# https://github.com/taiki-e/cargo-llvm-cov/issues/446
+[target.thumbv8m.main-none-eabi]
+rustflags = ["-Z", "panic-abort-tests"]
+[target.'thumbv8m.base-none-eabi']
+rustflags = ["-Z", "panic-abort-tests"]
+
 # [target.<triple>.<links>] # `links` build script override
 # rustc-link-lib = ["foo"]
 # rustc-link-search = ["/path/to/foo"]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -217,6 +217,14 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
         Some(["b", "bb", "c", "cc"].into())
     );
     assert_eq!(config.rustdocflags("x86_64-unknown-linux-gnu").unwrap(), Some(["d", "dd"].into()));
+    assert_eq!(
+        config.rustflags("thumbv8m.main-none-eabi").unwrap(),
+        Some(["-Z", "panic-abort-tests"].into())
+    );
+    assert_eq!(
+        config.rustflags("thumbv8m.base-none-eabi").unwrap(),
+        Some(["-Z", "panic-abort-tests"].into())
+    );
     // TODO: [target.<triple>.<links>]
 
     // resolved target config cannot be accessed by cfg(...)


### PR DESCRIPTION
Fixes https://github.com/taiki-e/cargo-llvm-cov/issues/446


However, according to https://github.com/rust-lang/cargo/issues/15901#issuecomment-3270887135, is the fact that this is supported also unintended for Cargo...?

cc @jonathanpallant
