### PR TITLE
Support `target.'cfg(..)'.rustdocflags` and handle empty target flags.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -331,8 +331,28 @@ impl Config {
                         target_rustflags @ None => *target_rustflags = Some(rustflags.clone()),
                     }
                 }
+                // Applied order (as of 1.97.1):
+                // 1. target.<triple>.rustdocflags
+                // 2. CARGO_TARGET_<triple>_RUSTDOCFLAGS
+                // 3. target.<cfg>.rustdocflags
+                if let Some(rustdocflags) = v.rustdocflags.as_ref() {
+                    match &mut target_rustdocflags {
+                        Some(target_rustdocflags) => {
+                            target_rustdocflags.flags.extend_from_slice(&rustdocflags.flags);
+                        }
+                        target_rustdocflags @ None => {
+                            *target_rustdocflags = Some(rustdocflags.clone());
+                        }
+                    }
+                }
             }
         }
+
+        // Empty target flags do not override build flags, per cargo's behavior as of Rust 1.97.1.
+        target_rustflags = target_rustflags.filter(|rustflags| !rustflags.flags.is_empty());
+        target_rustdocflags =
+            target_rustdocflags.filter(|rustdocflags| !rustdocflags.flags.is_empty());
+
         if let Some(linker) = target_linker {
             target_config.get_or_insert_with(TargetConfig::default).linker = Some(linker);
         }
@@ -1384,6 +1404,7 @@ impl Flags {
     /// - `target.<cfg>.rustflags`
     /// - `build.rustflags`
     /// - `target.<triple>.rustdocflags` (Cargo 1.78+)
+    /// - `target.<cfg>.rustdocflags` (Cargo 1.96+)
     /// - `build.rustdocflags`
     ///
     /// See also `encode_space_separated`.

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -1423,6 +1423,7 @@ impl Flags {
     /// - `target.<cfg>.rustflags`
     /// - `build.rustflags`
     /// - `target.<triple>.rustdocflags` (Cargo 1.78+)
+    /// - `target.<cfg>.rustdocflags` (Cargo 1.96+)
     /// - `build.rustdocflags`
     ///
     /// See also [`encode_space_separated`](Self::encode_space_separated).
@@ -1471,6 +1472,7 @@ impl Flags {
     /// - `target.<cfg>.rustflags`
     /// - `build.rustflags`
     /// - `target.<triple>.rustdocflags` (Cargo 1.78+)
+    /// - `target.<cfg>.rustdocflags` (Cargo 1.96+)
     /// - `build.rustdocflags`
     ///
     /// # Errors

--- a/src/env.rs
+++ b/src/env.rs
@@ -240,6 +240,7 @@ impl ApplyEnv for BuildConfig {
         // 1. CARGO_ENCODED_RUSTDOCFLAGS
         // 2. RUSTDOCFLAGS
         // 3. target.<triple>.rustdocflags (CARGO_TARGET_<triple>_RUSTDOCFLAGS)
+        //    and target.<cfg>.rustdocflags
         // 4. build.rustdocflags (CARGO_BUILD_RUSTDOCFLAGS)
         // For 3, we handle it in de::Config::resolve_target.
         // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustdocflags

--- a/tests/fixtures/reference/.cargo/config.toml
+++ b/tests/fixtures/reference/.cargo/config.toml
@@ -145,6 +145,7 @@ objcopy = { path = "objcopy" }
 [target.'cfg(target_arch = "x86_64")']
 runner = "c" # wrapper to run executables
 rustflags = ["c", "cc"] # custom flags for `rustc`
+rustdocflags = ["e", "ee"] # custom flags for `rustdoc`
 strip = { path = "strip" }
 
 # https://github.com/taiki-e/cargo-llvm-cov/issues/446

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -207,7 +207,7 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
     );
     assert_eq!(
         config.target("x86_64-unknown-linux-gnu").unwrap().rustdocflags,
-        Some(["d", "dd"].into())
+        Some(["d", "dd", "e", "ee"].into())
     );
     assert_eq!(config.linker("x86_64-unknown-linux-gnu").unwrap().unwrap().as_os_str(), "b");
     assert_eq!(config.runner("x86_64-unknown-linux-gnu").unwrap().unwrap().path.as_os_str(), "b");
@@ -216,7 +216,10 @@ fn assert_reference_example(de: fn(&Path, ResolveOptions) -> Result<Config, Erro
         config.rustflags("x86_64-unknown-linux-gnu").unwrap(),
         Some(["b", "bb", "c", "cc"].into())
     );
-    assert_eq!(config.rustdocflags("x86_64-unknown-linux-gnu").unwrap(), Some(["d", "dd"].into()));
+    assert_eq!(
+        config.rustdocflags("x86_64-unknown-linux-gnu").unwrap(),
+        Some(["d", "dd", "e", "ee"].into())
+    );
     assert_eq!(
         config.rustflags("thumbv8m.main-none-eabi").unwrap(),
         Some(["-Z", "panic-abort-tests"].into())
@@ -287,6 +290,35 @@ fn no_manifest_dir() {
         "",
         toml::to_string(&Config::load_with_options(tmpdir.path(), test_options()).unwrap())
             .unwrap()
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support std::process::Command: https://github.com/rust-lang/miri/issues/3374
+fn empty_target_flags_fall_back_to_build() {
+    let (_tmp, root) = test_project("empty");
+    fs::write(
+        root.join(".cargo/config.toml"),
+        r#"
+            [build]
+            rustflags = ["--cfg", "from_build_rustflags"]
+            rustdocflags = ["--cfg", "from_build_rustdocflags"]
+
+            [target.'cfg(target_arch = "x86_64")']
+            rustflags = []
+            rustdocflags = []
+            "#,
+    )
+    .unwrap();
+
+    let config = Config::load_with_options(&root, test_options()).unwrap();
+    assert_eq!(
+        config.rustflags("x86_64-unknown-linux-gnu").unwrap(),
+        Some(["--cfg", "from_build_rustflags"].into())
+    );
+    assert_eq!(
+        config.rustdocflags("x86_64-unknown-linux-gnu").unwrap(),
+        Some(["--cfg", "from_build_rustdocflags"].into())
     );
 }
 


### PR DESCRIPTION
Cargo as of Rust 1.96 supports `target.'cfg(..)'.rustdocflags`, and this PR implements that functionality.

Additionally, empty rustflags and rustdocflags in the `target` section are not respected by cargo, instead dropping back to general build flags. This PR also implements this behavior for both rustflags and rustdocflags, adding a regression test as well.

Resolves #48.