### PR TITLE
Treat empty encoded flags as a zero-flag override.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1696,7 +1696,10 @@ pub(crate) fn target_u_upper(target: &str) -> String {
 }
 
 pub(crate) fn split_encoded(s: &str) -> impl Iterator<Item = &str> {
-    s.split('\x1f')
+    // Cargo treats an entirely empty value as no flags,
+    // but preserves empty components in a non-empty value:
+    // https://github.com/rust-lang/cargo/blob/c980f4866141969fab6254a680546a277789d6f0/src/cargo/core/compiler/build_context/target_info.rs#L825-L833
+    (!s.is_empty()).then(|| s.split('\x1f')).into_iter().flatten()
 }
 pub(crate) fn split_space_separated(s: &str) -> impl Iterator<Item = &str> {
     // TODO: tab/line?

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -322,6 +322,43 @@ fn empty_target_flags_fall_back_to_build() {
     );
 }
 
+#[test]
+fn flags_from_encoded() {
+    for (encoded, expected) in [
+        ("", Flags::default()),
+        ("\x1f", ["", ""].into()),
+        ("\x1fa\x1f", ["", "a", ""].into()),
+        ("a\x1fb", ["a", "b"].into()),
+    ] {
+        assert_eq!(Flags::from_encoded(encoded), expected);
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support std::process::Command: https://github.com/rust-lang/miri/issues/3374
+fn empty_encoded_flags_override_other_sources() {
+    let (_tmp, root) = test_project("empty");
+    fs::write(
+        root.join(".cargo/config.toml"),
+        r#"
+            [build]
+            rustflags = ["from_build_rustflags"]
+            rustdocflags = ["from_build_rustdocflags"]
+
+            [target.x86_64-unknown-linux-gnu]
+            rustflags = ["from_target_rustflags"]
+            rustdocflags = ["from_target_rustdocflags"]
+            "#,
+    )
+    .unwrap();
+
+    let options =
+        test_options().env([("CARGO_ENCODED_RUSTFLAGS", ""), ("CARGO_ENCODED_RUSTDOCFLAGS", "")]);
+    let config = Config::load_with_options(&root, options).unwrap();
+    assert_eq!(config.rustflags("x86_64-unknown-linux-gnu").unwrap(), Some(Flags::default()));
+    assert_eq!(config.rustdocflags("x86_64-unknown-linux-gnu").unwrap(), Some(Flags::default()));
+}
+
 fn de_load(dir: &Path, _cx: ResolveOptions) -> Result<de::Config, Error> {
     de::Config::load_with_options(dir, None)
 }


### PR DESCRIPTION
Cargo special-cases a wholly empty `CARGO_ENCODED_RUSTFLAGS` or `CARGO_ENCODED_RUSTDOCFLAGS` value as an override containing zero flags, rather than one containing a single empty flag.

Adjust `cargo-config2`'s implementation to match.